### PR TITLE
FIX - prometheus volumes.1 must be a string

### DIFF
--- a/templates/compose.yaml.j2
+++ b/templates/compose.yaml.j2
@@ -37,7 +37,7 @@ services:
     volumes:
       - ./config/prometheus.yaml:/etc/prometheus/prometheus.yaml
 {% if gc_prometheus_bind_mount_dir_sanitized %}
-      - - {{ gc_prometheus_bind_mount_dir_sanitized }}:/prometheus
+      - {{ gc_prometheus_bind_mount_dir_sanitized }}:/prometheus
 {% else %}
       - prometheus-data:/prometheus
 {% endif %}


### PR DESCRIPTION
Faced an issue regarding prometheus volume when trying to setup.
error message was `validating /srv/GrafanaCompose/compose.yaml: services.prometheus.volumes.1 must be a string`
